### PR TITLE
fix: Remove Moq and Castle.Core from HelloApi

### DIFF
--- a/HelloApi/HelloApi/HelloApi.csproj
+++ b/HelloApi/HelloApi/HelloApi.csproj
@@ -137,13 +137,7 @@
     <Reference Include="Unity.Mvc">
       <HintPath>..\packages\Unity.Mvc.5.11.1\lib\net46\Unity.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="Castle.Core">
-      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
-    </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="Moq">
-      <HintPath>..\packages\Moq.4.16.1\lib\net45\Moq.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">

--- a/HelloApi/HelloApi/packages.config
+++ b/HelloApi/HelloApi/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net461" />
   <package id="bootstrap" version="3.4.1" targetFramework="net461" />
-  <package id="Castle.Core" version="4.4.0" targetFramework="net462" />
   <package id="DogStatsD-CSharp-Client" version="6.0.0" targetFramework="net462" />
   <package id="jQuery" version="3.4.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net461" />
@@ -17,7 +16,6 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Modernizr" version="2.8.3" targetFramework="net461" />
-  <package id="Moq" version="4.16.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />


### PR DESCRIPTION
Moq is required for testing, but not in HelloApi.
Castle.Core is required by Moq.